### PR TITLE
Correct gpugrid progress

### DIFF
--- a/sync/atm.py
+++ b/sync/atm.py
@@ -136,7 +136,7 @@ class openmm_job_AmberRBFE:
                                 replica.save_checkpoint()
 
                     # Report progress on GPUGRID
-                    progress = float(isample)/float(num_samples - last_sample)
+                    progress = float(isample - last_sample + 1)/float(num_samples - last_sample + 1)
                     open("progress", "w").write(str(progress))
 
     def _updateReplicas(self):


### PR DESCRIPTION
- Make denominator match MAX_SAMPLES
- Make numerator iterate from 1=>MAX_SAMPLES 
 
This achieves correct 0=>100% progress indicator on BOINC for GPUGRID, preventing users from aborting seemingly unresponsive tasks.

Fixes Gallicchio-Lab/AToM-OpenMM#46
